### PR TITLE
chore(deps): bump @maticnetwork/maticjs to ^3.9.10

### DIFF
--- a/.changeset/spicy-roses-act.md
+++ b/.changeset/spicy-roses-act.md
@@ -1,0 +1,26 @@
+---
+'proof-generation-api': patch
+---
+
+Fix exit proofs failing on-chain for Bor state-sync transactions, and
+harden the checkpoint binary search against edge cases and reorg races.
+
+Both fixes come from `@maticnetwork/maticjs@3.9.10`
+([matic.js#465](https://github.com/0xPolygon/matic.js/pull/465)),
+adopted here by bumping the pin from `3.9.7` to `^3.9.10`.
+
+- Exit proofs derived from a Bor state-sync transaction (which always
+  has `cumulativeGasUsed = 0`) now encode the receipt with the canonical
+  RLP empty byte string (`0x80`) instead of the literal `0x00`. The
+  buggy encoding previously made every such proof return `200 OK` here
+  but revert on-chain with `INVALID_RECEIPT_MERKLE_PROOF`. `lst-api`
+  has been carrying a client-side `fixExitProofEncoding` workaround
+  for this; it can drop the workaround once this rolls.
+
+- The checkpoint binary search no longer returns a slot that does not
+  actually contain the burn block. Previously a burn block past every
+  existing checkpoint silently produced a proof embedding an unrelated
+  header, and the two reads inside the search used different block
+  tags, opening a race against an un-finalised checkpoint that could
+  reorg out before submission. Both reads now use the same block tag
+  and the converged slot is range-verified.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.4.1",
-    "@maticnetwork/maticjs": "3.9.7",
+    "@maticnetwork/maticjs": "^3.9.10",
     "@maticnetwork/maticjs-ethers": "^1.1.0",
     "@polygonlabs/logger": "^1.0.1",
     "@polygonlabs/verror": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^8.4.1
         version: 8.4.2(zod@4.3.6)
       '@maticnetwork/maticjs':
-        specifier: 3.9.7
-        version: 3.9.7
+        specifier: ^3.9.10
+        version: 3.9.10
       '@maticnetwork/maticjs-ethers':
         specifier: ^1.1.0
-        version: 1.1.0(@maticnetwork/maticjs@3.9.7)
+        version: 1.1.0(@maticnetwork/maticjs@3.9.10)
       '@polygonlabs/logger':
         specifier: ^1.0.1
         version: 1.0.1(@sentry/node@10.41.0)(pino-pretty@13.1.3)
@@ -630,8 +630,8 @@ packages:
     peerDependencies:
       '@maticnetwork/maticjs': ^3.2.5
 
-  '@maticnetwork/maticjs@3.9.7':
-    resolution: {integrity: sha512-dyboO3XCfpf5MOadHY/7N8oajKZD33EOdzGzBS1g9Bbuzdos0rwmaMWpWvpm6XAJe41xkiq779W4iEhuZqvDQw==}
+  '@maticnetwork/maticjs@3.9.10':
+    resolution: {integrity: sha512-GMtO1wTjETyZs1rCZWNqxsSPTmO/evq9XWfDu0OsIT45JtrSmraUi2puV87wQm0mfzr2dkhOgOdxwS2IwhycCw==}
     engines: {node: '>=8.0.0'}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -4327,17 +4327,18 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@maticnetwork/maticjs-ethers@1.1.0(@maticnetwork/maticjs@3.9.7)':
+  '@maticnetwork/maticjs-ethers@1.1.0(@maticnetwork/maticjs@3.9.10)':
     dependencies:
-      '@maticnetwork/maticjs': 3.9.7
+      '@maticnetwork/maticjs': 3.9.10
       ethers: 5.8.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@maticnetwork/maticjs@3.9.7':
+  '@maticnetwork/maticjs@3.9.10':
     dependencies:
       '@ethereumjs/block': 5.3.0
+      '@ethereumjs/common': 4.4.0
       '@ethereumjs/trie': 6.2.1
       '@ethereumjs/util': 9.1.0
       assert: 2.1.0
@@ -4346,6 +4347,7 @@ snapshots:
       ethereum-cryptography: 2.2.1
       node-fetch: 2.7.0
       rlp: 3.0.0
+      safe-buffer: 5.2.1
       stream: 0.0.3
     transitivePeerDependencies:
       - encoding

--- a/src/test/exit-payload-state-sync.test.ts
+++ b/src/test/exit-payload-state-sync.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression — non-canonical encoding of `cumulativeGasUsed = 0`
+ *
+ * `getReceiptBytes` in `@maticnetwork/maticjs` used to wrap every receipt
+ * field in `BufferUtil.toBuffer` before passing to `rlp.encode`. For an
+ * integer field whose value is `0`, that produced `<Buffer 00>`, which
+ * RLP-encodes to the single byte `0x00`. The canonical RLP encoding of
+ * integer 0 is the empty byte string (`0x80`).
+ *
+ * Bor (go-ethereum) writes `receiptsRoot` using the canonical encoding,
+ * so any exit proof derived from a Bor state-sync transaction (which
+ * always has `cumulativeGasUsed = 0`) failed on-chain `MerklePatriciaProof.verify`
+ * with `INVALID_RECEIPT_MERKLE_PROOF`. Fixed in matic.js#465 / 3.9.10.
+ *
+ * This test pins the bug case end-to-end through the API:
+ *
+ *   - Anchor: a real Bor state-sync receipt on Amoy block 37337056 (the
+ *     same fixture matic.js's own unit test uses), tx
+ *     `0x512dc8ec…`. The receipt has `type=0x7f`, `cumulativeGasUsed=0`,
+ *     and 7 `LogTransfer` events from the system token.
+ *   - The block's on-chain `receiptsRoot` is immutable
+ *     (`0xb25e9efe…`) — verifiable on the Amoy explorer.
+ *   - We fetch the exit-payload via the API for one of the in-receipt
+ *     `LogTransfer` events, then assert (a) the embedded `receiptsRoot`
+ *     matches the on-chain anchor and (b) the receipt bytes RLP-decode
+ *     such that `cumulativeGasUsed` is the empty byte string (canonical),
+ *     never the literal `0x00`.
+ *
+ * If matic.js ever regresses on the canonical encoding — or this service
+ * accidentally pins to a buggy version — assertion (b) fails immediately
+ * with a clear diff against `0x80`.
+ */
+
+import { ethers } from 'ethers';
+import { describe, expect, it } from 'vitest';
+
+import { getAgent } from './helpers/agent.ts';
+import { decodeExitPayload } from './helpers/decode-exit-payload.ts';
+
+// Amoy block 37337056, tx index 0 — a single Bor state-sync transaction
+// with type=0x7f, cumulativeGasUsed=0, and 7 LogTransfer logs from the
+// child gas token (0x...1010).
+const STATE_SYNC_TX = '0x512dc8ec81bd8d41c163396cab01c9320e9ff67947189065038ea7b94cb66e89';
+
+// `LogTransfer(address,address,address,uint256,uint256,uint256,uint256,uint256)` —
+// emitted by the Bor child gas token on every state-sync. Picked as the
+// event signature because it's reliably present in the receipt; the
+// bridge-validity of the resulting proof is irrelevant here, only the
+// canonical encoding of the receipt bytes is.
+const LOG_TRANSFER_SIG = '0xe6497e3ee548a3372136af2fcb0696db31fc6cf20260707645068bd3fe97f3c4';
+
+// Immutable on-chain anchor for the block. Verifiable on Amoy explorer:
+// block 37337056 → "Receipts Root" field. Pinning this guards against
+// any encoding regression *anywhere* in the receipt — the trie root
+// derives from the keccak of the encoded receipt, so a single
+// non-canonical byte produces a different root.
+const RECEIPTS_ROOT = '0xb25e9efe7b0a26e11f8927e2c85f57e62e195136270225c7d1f4a129bf3f475c';
+
+describe('amoy exit payload — Bor state-sync receipt regression', { timeout: 60_000 }, () => {
+  it('encodes cumulativeGasUsed=0 as the canonical empty byte string (not 0x00)', async () => {
+    const res = await getAgent().get(
+      `/api/v1/amoy/exit-payload/${STATE_SYNC_TX}?eventSignature=${LOG_TRANSFER_SIG}`
+    );
+
+    expect(res).property('status', 200);
+    expect(res).nested.property('body.result').a('string');
+
+    const result = res.body.result as string;
+    expect(result).match(/^0x[0-9a-f]+$/i);
+
+    // Strong end-to-end check: the embedded receiptsRoot must equal the
+    // on-chain anchor. If any byte of the encoded receipt is wrong, the
+    // trie root mismatches and this fails before we even decode.
+    const { receiptsRoot } = decodeExitPayload(result);
+    expect(receiptsRoot).equal(RECEIPTS_ROOT);
+
+    // Specific check on the cumulativeGasUsed encoding. Decode field [6]
+    // (receipt bytes), strip the EIP-2718 type prefix if present, then
+    // RLP-decode into [status, cumulativeGasUsed, logsBloom, logs[]].
+    const fields = ethers.utils.RLP.decode(result) as string[];
+    let receiptHex = fields[6] as string;
+    if (parseInt(receiptHex.slice(2, 4), 16) < 0x80) receiptHex = '0x' + receiptHex.slice(4);
+    const decoded = ethers.utils.RLP.decode(receiptHex as `0x${string}`) as string[];
+
+    // Canonical RLP of integer 0 is the empty byte string. ethers' RLP
+    // decoder returns it as the literal string '0x' (zero data bytes).
+    // The buggy encoding returns '0x00' (one data byte).
+    expect(decoded[1], 'cumulativeGasUsed must be canonical empty bytes (0x), never 0x00').equal(
+      '0x'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Bumps `@maticnetwork/maticjs` from `3.9.7` to `^3.9.10` so generated exit proofs adopt two upstream fixes from matic.js [#465](https://github.com/0xPolygon/matic.js/pull/465). Adds an integration test pinning the broken case so CI catches any regression.

## Why

`lst-api` is post-processing every L2→L1 exit proof with a local `fixExitProofEncoding` workaround because matic.js's `getReceiptBytes` produced a non-canonical RLP encoding for `cumulativeGasUsed = 0` — every Bor state-sync transaction. Without the workaround, exit proofs returned by this service got `200 OK` but reverted on-chain with `INVALID_RECEIPT_MERKLE_PROOF`. matic.js#465 fixes the encoding upstream; rolling that into this service lets `lst-api` drop its workaround in [#106](https://github.com/0xPolygon/lst-api/pull/106).

The same matic.js PR also hardens `RootChain.findRootBlockFromChild`'s binary search so it no longer returns a checkpoint slot that doesn't actually contain the burn block, and uses a consistent block tag across both reads to close a reorg race.

## Regression test

`src/test/exit-payload-state-sync.test.ts` hits `/api/v1/amoy/exit-payload/<tx>` for the production-failure-shape receipt (Amoy block 37337056, tx `0x512dc8ec…` — same fixture matic.js's own unit test uses). It then asserts:

1. The embedded `receiptsRoot` equals the immutable on-chain anchor `0xb25e9efe…`. Any byte-level encoding error anywhere in the receipt produces a different trie root — strongest possible end-to-end check.
2. The receipt's `cumulativeGasUsed` field RLP-decodes to the empty byte string (canonical RLP zero), never the literal `0x00`.

If matic.js ever regresses, or this service accidentally pins to a buggy version, this test fails on the first PR run.

## Version history

`3.9.8` was burned by an earlier non-canonical publish from `chore/monorepo` (deprecated). `3.9.9` published an empty tarball because of a missing `prepublishOnly` hook (also deprecated; fixed in matic.js#471). `3.9.10` is the first healthy release containing the fixes — 107 files / 4.27 MB.

## Test plan

- [ ] CI green — including the new `exit-payload-state-sync` test
- [ ] Once deployed, [`lst-api#106`](https://github.com/0xPolygon/lst-api/pull/106) is unblocked