### PR TITLE
chore: fix changeset pre-push hook in linked worktrees

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,6 +15,14 @@ base_branch=$(grep '"baseBranch"' .changeset/config.json | sed 's/.*"baseBranch"
 # If origin/<base_branch> doesn't exist yet (brand-new repo), nothing to compare against.
 git rev-parse --verify "origin/$base_branch" > /dev/null 2>&1 || exit 0
 
+# Git sets GIT_DIR / GIT_WORK_TREE to the worktree's gitdir when running hooks
+# inside a linked worktree (e.g. one created via `git worktree add`). Those vars
+# break `changeset status` — it invokes its own `git` subprocesses, which then
+# read from the linked gitdir rather than the worktree's actual tree, and report
+# "no changesets found" even when a valid one exists. Unset both so changeset's
+# git calls resolve against the CWD the hook is running in.
+unset GIT_DIR GIT_WORK_TREE
+
 if ! pnpm exec changeset status --since="origin/$base_branch" 2>/dev/null; then
   echo ""
   echo "  No changeset found. Add one before pushing:"


### PR DESCRIPTION
Git exports `GIT_DIR`/`GIT_WORK_TREE` to hooks running inside linked git worktrees (e.g. ones created via `git worktree add`). Those variables make `changeset status`'s own git subprocesses read the linked gitdir instead of the worktree's actual tree, so the pre-push hook falsely reports "no changesets found" even when a valid changeset exists.

This syncs `.husky/pre-push` with apps-team-ts-template's canonical version, which unsets both variables before invoking changesets. CI/tooling-only — no runtime or package changes.

https://claude.ai/code/session_01928TnCS4kMQPd6uVTewNSN
