### PR TITLE
ci: point release-gate AMOY_RPC at eRPC — public amoy endpoint retired

### DIFF
--- a/.changeset/release-gate-amoy-erpc.md
+++ b/.changeset/release-gate-amoy-erpc.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: release-gate AMOY_RPC moved off the retired public amoy endpoint; no runtime change.

--- a/.github/workflows/docker-release-trigger.yml
+++ b/.github/workflows/docker-release-trigger.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # RPC URLs required by the service at runtime and during tests.
-      # AMOY_RPC is a public endpoint with no secret.
-      # ETHEREUM_RPC, MATIC_RPC, and SEPOLIA_RPC use an eRPC client token.
-      AMOY_RPC: '["https://rpc-amoy.polygon.technology"]'
+      # All four use the eRPC client token. AMOY_RPC previously pointed at the
+      # public rpc-amoy.polygon.technology endpoint, which no longer resolves —
+      # ci-trigger.yml had already moved to the eRPC URL, this file never did.
+      AMOY_RPC: '["https://rpc.polygon.tools/internal/evm/80002?token=${{ secrets.ERPC_CLIENT_TOKEN }}"]'
       ETHEREUM_RPC: '["https://rpc.polygon.tools/internal/evm/1?token=${{ secrets.ERPC_CLIENT_TOKEN }}"]'
       MATIC_RPC: '["https://rpc.polygon.tools/internal/evm/137?token=${{ secrets.ERPC_CLIENT_TOKEN }}"]'
       SEPOLIA_RPC: '["https://rpc.polygon.tools/internal/evm/11155111?token=${{ secrets.ERPC_CLIENT_TOKEN }}"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#89](https://github.com/0xPolygon/proof-generation-api/pull/89) [`58a7e8b`](https://github.com/0xPolygon/proof-generation-api/commit/58a7e8bd4c7212544177f2c1e41ef6e530604c88) Thanks [@shan8851](https://github.com/shan8851)! - Remove the zkEVM proof-generation endpoints (`/zkevm/mainnet` and `/zkevm/testnet` routes) — the underlying chains are sunset and their infrastructure no longer answers. PoS (v1) endpoints are unchanged.
 
   ## Breaking changes
+
   - Removed `GET /api/zkevm/{network}/bridge`
   - Removed `GET /api/zkevm/{network}/merkle-proof`
   - Removed the `ZKEVM_MAINNET_URL` and `ZKEVM_TESTNET_URL` environment variables — they are no longer recognized configuration


### PR DESCRIPTION
The Docker release gate's `AMOY_RPC` still pointed at `rpc-amoy.polygon.technology`, which no longer resolves (retired); `ci-trigger.yml` had already moved to the eRPC URL, which is why PR CI stayed green while every release-tag run for 2.0.0 failed (5×, run 31686169287 + rc proofs). One-line swap to the same eRPC pattern as the other three chains, plus the MD022 changelog lint fix that was blocking CI.

After merge: no new version needed — re-dispatch the existing `proof-generation-api@2.0.0` tag (`workflow_dispatch` uses this fixed workflow from master while building the tag's code). Supersedes the warm-up approach in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)